### PR TITLE
reduce terraform-boot docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
-FROM eclipse-temurin:17
+FROM eclipse-temurin:17-jre-alpine
 
-RUN apt-get update && \
-    apt-get install unzip wget -y
+RUN addgroup -S terraform-boot && adduser -S -G terraform-boot terraform-boot
+RUN apk update && \
+    apk add --no-cache unzip wget
 ENV TERRAFORM_VERSION=1.4.4
 RUN wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 RUN unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 RUN mv terraform /usr/bin/terraform
 COPY target/terraform-boot-*.jar terraform-boot.jar
+USER terraform-boot
 ENTRYPOINT ["java","-jar","terraform-boot.jar"]


### PR DESCRIPTION
fixes eclipse-xpanse/xpanse#776

[
![08 22-docker](https://github.com/eclipse-xpanse/terraform-boot/assets/121534745/e6d8ba3d-66f9-4d8d-aee5-018c030d1658)
](url)