### PR TITLE
revert POM version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 	</parent>
 	<groupId>org.eclipse.xpanse.terraform.boot</groupId>
 	<artifactId>terraform-boot</artifactId>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>0.0.0-SNAPSHOT</version>
 	<name>terraform-boot</name>
 	<description>RESTful API Wrapper for Terraform</description>
 	<properties>


### PR DESCRIPTION
fixes https://github.com/eclipse-xpanse/xpanse/issues/930
revert the pom version changes made by a faulty release job. 