### PR TITLE
support multiple versions of terraform

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.3.3</version>
+		<version>3.3.4</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>org.eclipse.xpanse.terraform.boot</groupId>
@@ -20,7 +20,7 @@
 	<description>RESTful API Wrapper for Terraform</description>
 	<properties>
 		<java.version>21</java.version>
-		<spring.retry.version>2.0.8</spring.retry.version>
+		<spring.retry.version>2.0.9</spring.retry.version>
 		<springdoc.version>2.6.0</springdoc.version>
 		<checkstyle-maven-plugin.version>3.5.0</checkstyle-maven-plugin.version>
 		<logbook.version>3.9.0</logbook.version>
@@ -29,6 +29,8 @@
 		<opentelemetry.version>1.32.0</opentelemetry.version>
 		<eclipse.dash.tool.plugin>1.1.0</eclipse.dash.tool.plugin>
 		<jgit.version>7.0.0.202409031743-r</jgit.version>
+		<semver4j.version>5.4.0</semver4j.version>
+		<jsoup.version>1.18.1</jsoup.version>
 		<maven.complier.plugin.version>3.13.0</maven.complier.plugin.version>
 		<maven.surefire.plugin.version>3.5.0</maven.surefire.plugin.version>
 		<maven.enforcer.plugin.version>3.5.0</maven.enforcer.plugin.version>
@@ -110,6 +112,16 @@
 			<groupId>org.springframework.retry</groupId>
 			<artifactId>spring-retry</artifactId>
 			<version>${spring.retry.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.semver4j</groupId>
+			<artifactId>semver4j</artifactId>
+			<version>${semver4j.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.jsoup</groupId>
+			<artifactId>jsoup</artifactId>
+			<version>${jsoup.version}</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/org/eclipse/xpanse/terraform/boot/api/controllers/TerraformBootFromDirectoryApi.java
+++ b/src/main/java/org/eclipse/xpanse/terraform/boot/api/controllers/TerraformBootFromDirectoryApi.java
@@ -11,6 +11,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import java.util.Objects;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
@@ -24,6 +26,7 @@ import org.eclipse.xpanse.terraform.boot.models.request.directory.TerraformDestr
 import org.eclipse.xpanse.terraform.boot.models.request.directory.TerraformModifyFromDirectoryRequest;
 import org.eclipse.xpanse.terraform.boot.models.response.TerraformResult;
 import org.eclipse.xpanse.terraform.boot.models.validation.TerraformValidationResult;
+import org.eclipse.xpanse.terraform.boot.terraform.TerraformVersionHelper;
 import org.eclipse.xpanse.terraform.boot.terraform.service.TerraformDirectoryService;
 import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -67,15 +70,20 @@ public class TerraformBootFromDirectoryApi {
     @Tag(name = "TerraformFromDirectory", description =
             "APIs for running Terraform commands inside a provided directory.")
     @Operation(description = "Validate the Terraform modules in the given directory.")
-    @GetMapping(value = "/validate/{module_directory}", produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(value = "/validate/{module_directory}/{terraform_version}", produces =
+            MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public TerraformValidationResult validateFromDirectory(
             @Parameter(name = "module_directory",
                     description = "directory name where the Terraform module files exist.")
-            @PathVariable("module_directory") String moduleDirectory) {
+            @PathVariable("module_directory") String moduleDirectory,
+            @Parameter(name = "terraform_version",
+                    description = "version of Terraform to execute the module files.")
+            @NotBlank @Pattern(regexp = TerraformVersionHelper.TERRAFORM_REQUIRED_VERSION_REGEX)
+            @PathVariable("terraform_version") String terraformVersion) {
         UUID uuid = UUID.randomUUID();
         MDC.put(REQUEST_ID, uuid.toString());
-        return terraformDirectoryService.tfValidateFromDirectory(moduleDirectory);
+        return terraformDirectoryService.tfValidateFromDirectory(moduleDirectory, terraformVersion);
     }
 
     /**

--- a/src/main/java/org/eclipse/xpanse/terraform/boot/models/exceptions/InvalidTerraformToolException.java
+++ b/src/main/java/org/eclipse/xpanse/terraform/boot/models/exceptions/InvalidTerraformToolException.java
@@ -1,0 +1,16 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ */
+
+package org.eclipse.xpanse.terraform.boot.models.exceptions;
+
+/**
+ * Defines possible exceptions returned by Terraform version invalid.
+ */
+public class InvalidTerraformToolException extends RuntimeException {
+
+    public InvalidTerraformToolException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/eclipse/xpanse/terraform/boot/models/exceptions/TerraformApiExceptionHandler.java
+++ b/src/main/java/org/eclipse/xpanse/terraform/boot/models/exceptions/TerraformApiExceptionHandler.java
@@ -116,4 +116,16 @@ public class TerraformApiExceptionHandler {
         return Response.errorResponse(ResultType.INVALID_GIT_REPO_DETAILS,
                 Collections.singletonList(failMessage));
     }
+
+    /**
+     * Exception handler for UnsupportedEnumValueException.
+     */
+    @ExceptionHandler({InvalidTerraformToolException.class})
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ResponseBody
+    public Response handleInvalidTerraformToolException(
+            InvalidTerraformToolException ex) {
+        return Response.errorResponse(ResultType.INVALID_TERRAFORM_TOOL,
+                Collections.singletonList(ex.getMessage()));
+    }
 }

--- a/src/main/java/org/eclipse/xpanse/terraform/boot/models/plan/TerraformPlan.java
+++ b/src/main/java/org/eclipse/xpanse/terraform/boot/models/plan/TerraformPlan.java
@@ -17,6 +17,9 @@ import lombok.Data;
 @Builder
 public class TerraformPlan {
 
+    @Schema(description = "Version of terraform")
+    String terraformVersion;
+
     @NotNull
     @Schema(description = "Terraform plan as a JSON string")
     String plan;

--- a/src/main/java/org/eclipse/xpanse/terraform/boot/models/plan/TerraformPlanFromDirectoryRequest.java
+++ b/src/main/java/org/eclipse/xpanse/terraform/boot/models/plan/TerraformPlanFromDirectoryRequest.java
@@ -6,11 +6,14 @@
 package org.eclipse.xpanse.terraform.boot.models.plan;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import lombok.Data;
+import org.eclipse.xpanse.terraform.boot.terraform.TerraformVersionHelper;
 
 /**
  * Data model for the generating terraform plan.
@@ -20,6 +23,12 @@ public class TerraformPlanFromDirectoryRequest {
 
     @Schema(description = "Id of the request.")
     UUID requestId;
+
+    @NotNull
+    @NotBlank
+    @Pattern(regexp = TerraformVersionHelper.TERRAFORM_REQUIRED_VERSION_REGEX)
+    @Schema(description = "The required version of the terraform which will execute the scripts.")
+    String terraformVersion;
 
     @NotNull
     @Schema(description = "Key-value pairs of variables that must be used to execute the "

--- a/src/main/java/org/eclipse/xpanse/terraform/boot/models/request/directory/TerraformDeployFromDirectoryRequest.java
+++ b/src/main/java/org/eclipse/xpanse/terraform/boot/models/request/directory/TerraformDeployFromDirectoryRequest.java
@@ -6,11 +6,14 @@
 package org.eclipse.xpanse.terraform.boot.models.request.directory;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import lombok.Data;
+import org.eclipse.xpanse.terraform.boot.terraform.TerraformVersionHelper;
 
 /**
  * Data model for the terraform deploy requests.
@@ -22,8 +25,14 @@ public class TerraformDeployFromDirectoryRequest {
     UUID requestId;
 
     @NotNull
+    @NotBlank
+    @Pattern(regexp = TerraformVersionHelper.TERRAFORM_REQUIRED_VERSION_REGEX)
+    @Schema(description = "The required version of the terraform which will execute the scripts.")
+    String terraformVersion;
+
+    @NotNull
     @Schema(description = "Flag to control if the deployment must only generate the terraform "
-                + "or it must also apply the changes.")
+            + "or it must also apply the changes.")
     Boolean isPlanOnly;
 
     @NotNull

--- a/src/main/java/org/eclipse/xpanse/terraform/boot/models/request/directory/TerraformDestroyFromDirectoryRequest.java
+++ b/src/main/java/org/eclipse/xpanse/terraform/boot/models/request/directory/TerraformDestroyFromDirectoryRequest.java
@@ -8,11 +8,14 @@ package org.eclipse.xpanse.terraform.boot.models.request.directory;
 import static io.swagger.v3.oas.annotations.media.Schema.AdditionalPropertiesValue.TRUE;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import lombok.Data;
+import org.eclipse.xpanse.terraform.boot.terraform.TerraformVersionHelper;
 
 /**
  * Data model for the terraform destroy requests.
@@ -22,6 +25,12 @@ public class TerraformDestroyFromDirectoryRequest {
 
     @Schema(description = "Id of the request")
     UUID requestId;
+
+    @NotNull
+    @NotBlank
+    @Pattern(regexp = TerraformVersionHelper.TERRAFORM_REQUIRED_VERSION_REGEX)
+    @Schema(description = "The required version of the terraform which will execute the scripts.")
+    String terraformVersion;
 
     @NotNull
     @Schema(description = "Key-value pairs of regular variables that must be used to execute the "

--- a/src/main/java/org/eclipse/xpanse/terraform/boot/models/request/directory/TerraformModifyFromDirectoryRequest.java
+++ b/src/main/java/org/eclipse/xpanse/terraform/boot/models/request/directory/TerraformModifyFromDirectoryRequest.java
@@ -8,11 +8,14 @@ package org.eclipse.xpanse.terraform.boot.models.request.directory;
 import static io.swagger.v3.oas.annotations.media.Schema.AdditionalPropertiesValue.TRUE;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import lombok.Data;
+import org.eclipse.xpanse.terraform.boot.terraform.TerraformVersionHelper;
 
 /**
  * Data model for the terraform modify requests.
@@ -22,6 +25,12 @@ public class TerraformModifyFromDirectoryRequest {
 
     @Schema(description = "Id of the request")
     UUID requestId;
+
+    @NotNull
+    @NotBlank
+    @Pattern(regexp = TerraformVersionHelper.TERRAFORM_REQUIRED_VERSION_REGEX)
+    @Schema(description = "The required version of the terraform which will execute the scripts.")
+    String terraformVersion;
 
     @NotNull
     @Schema(description = "Flag to control if the deployment must only generate the terraform "

--- a/src/main/java/org/eclipse/xpanse/terraform/boot/models/response/ResultType.java
+++ b/src/main/java/org/eclipse/xpanse/terraform/boot/models/response/ResultType.java
@@ -20,7 +20,8 @@ public enum ResultType {
     UNSUPPORTED_ENUM_VALUE("Unsupported Enum Value"),
     SERVICE_UNAVAILABLE("Service Unavailable"),
     UNAUTHORIZED("Unauthorized"),
-    INVALID_GIT_REPO_DETAILS("Invalid Git Repo Details");
+    INVALID_GIT_REPO_DETAILS("Invalid Git Repo Details"),
+    INVALID_TERRAFORM_TOOL("Invalid Terraform Tool");
 
     private final String value;
 

--- a/src/main/java/org/eclipse/xpanse/terraform/boot/models/response/TerraformResult.java
+++ b/src/main/java/org/eclipse/xpanse/terraform/boot/models/response/TerraformResult.java
@@ -20,7 +20,10 @@ import lombok.Data;
 public class TerraformResult {
 
     @Schema(description = "Id of the request")
-    UUID requestId;
+    private UUID requestId;
+    @NotNull
+    @Schema(description = "version of the terraform.")
+    private String terraformVersion;
     @NotNull
     @Schema(description = "defines if the command was successfully executed")
     private boolean isCommandSuccessful;

--- a/src/main/java/org/eclipse/xpanse/terraform/boot/models/validation/TerraformValidationResult.java
+++ b/src/main/java/org/eclipse/xpanse/terraform/boot/models/validation/TerraformValidationResult.java
@@ -16,6 +16,7 @@ import lombok.Data;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class TerraformValidationResult {
 
+    private String terraformVersion;
     private boolean valid;
     private List<TerraformValidateDiagnostics> diagnostics;
 }

--- a/src/main/java/org/eclipse/xpanse/terraform/boot/terraform/TerraformInstaller.java
+++ b/src/main/java/org/eclipse/xpanse/terraform/boot/terraform/TerraformInstaller.java
@@ -1,0 +1,202 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ */
+
+package org.eclipse.xpanse.terraform.boot.terraform;
+
+import jakarta.annotation.Resource;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.xpanse.terraform.boot.models.exceptions.InvalidTerraformToolException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Component;
+
+/**
+ * Bean help to install terraform with specific version.
+ */
+@Slf4j
+@Component
+public class TerraformInstaller {
+
+    @Value("${terraform.download.base.url:https://releases.hashicorp.com/terraform}")
+    private String terraformDownloadBaseUrl;
+    @Value("${terraform.install.dir:/opt/terraform}")
+    private String terraformInstallDir;
+    @Resource
+    private TerraformVersionHelper versionHelper;
+
+    /**
+     * Find the executable binary path of the Terraform tool that matches the required version.
+     * If no matching executable binary is found, install the Terraform tool with the required
+     * version and then return the path.
+     *
+     * @param requiredVersion The required version of Terraform tool.
+     * @return The path of the executable binary.
+     */
+    @Retryable(retryFor = InvalidTerraformToolException.class,
+            maxAttemptsExpression = "${spring.retry.max-attempts}",
+            backoff = @Backoff(delayExpression = "${spring.retry.delay-millions}"))
+    public String getExecutorPathThatMatchesRequiredVersion(String requiredVersion) {
+        if (StringUtils.isBlank(requiredVersion)) {
+            log.info("No required version of terraform is specified, use the default terraform.");
+            return "terraform";
+        }
+        String[] operatorAndNumber =
+                this.versionHelper.getOperatorAndNumberFromRequiredVersion(requiredVersion);
+        String requiredOperator = operatorAndNumber[0];
+        String requiredNumber = operatorAndNumber[1];
+        // Get path of the executor matched required version in the environment.
+        String matchedVersionExecutorPath =
+                this.versionHelper.getExecutorPathMatchedRequiredVersion(
+                        this.terraformInstallDir, requiredOperator, requiredNumber);
+        if (StringUtils.isBlank(matchedVersionExecutorPath)) {
+            log.info("Not found any terraform executor matched the required version {} from the "
+                            + "terraform installation dir {}, start to download and install one.",
+                    requiredVersion, this.terraformInstallDir);
+            return installTerraformByRequiredVersion(requiredOperator, requiredNumber);
+        }
+        return matchedVersionExecutorPath;
+    }
+
+    private String installTerraformByRequiredVersion(String requiredOperator,
+                                                     String requiredNumber) {
+        String matchedVersionNumber =
+                this.versionHelper.getBestAvailableVersionFromTerraformWebsite(
+                this.terraformDownloadBaseUrl, requiredOperator, requiredNumber);
+        if (StringUtils.isBlank(matchedVersionNumber)) {
+            String errorMsg = String.format("Not found any terraform executor matched the required "
+                            + "version %s from the terraform download url %s.",
+                    requiredOperator + requiredNumber, this.terraformDownloadBaseUrl);
+            log.error(errorMsg);
+            throw new InvalidTerraformToolException(errorMsg);
+        }
+        // Install the executor with specific version into the path.
+        String terraformExecutorName =
+                this.versionHelper.getTerraformExecutorName(matchedVersionNumber);
+        File terraformExecutorFile = new File(this.terraformInstallDir, terraformExecutorName);
+        File parentDir = terraformExecutorFile.getParentFile();
+        try {
+            if (!parentDir.exists()) {
+                log.info("Created the installation dir {} {}.", parentDir.getAbsolutePath(),
+                        parentDir.mkdirs() ? "successfully" : "failed");
+            }
+            // download the binary zip file into the installation directory
+            File terraformZipFile = downloadTerraformBinaryZipFile(matchedVersionNumber);
+            String executorName = terraformExecutorFile.getName();
+            // unzip the zip file and move the executable binary to the installation directory
+            unzipBinaryZipToGetExecutor(terraformZipFile, executorName);
+        } catch (IOException e) {
+            log.error(e.getMessage(), e);
+            throw new InvalidTerraformToolException(e.getMessage());
+        }
+        // delete the non-executable files
+        deleteNonExecutorFiles(parentDir);
+        // check the executable binary
+
+        if (this.versionHelper.checkIfExecutorVersionIsValid(
+                terraformExecutorFile, requiredOperator, requiredNumber)) {
+            log.info("Installed terraform version {} into the dir {} successfully.",
+                    terraformExecutorFile.getAbsolutePath(), requiredOperator + requiredNumber);
+            return terraformExecutorFile.getAbsolutePath();
+        }
+        String errorMsg = String.format("Installing terraform version %s into the dir %s failed. ",
+                requiredOperator + requiredNumber, this.terraformInstallDir);
+        log.error(errorMsg);
+        throw new InvalidTerraformToolException(errorMsg);
+    }
+
+
+    private File downloadTerraformBinaryZipFile(String versionNumber) throws IOException {
+        String binaryZipFileName = this.versionHelper.getTerraformBinaryFileName(versionNumber);
+        File binaryZipFile = new File(this.terraformInstallDir, binaryZipFileName);
+        String binaryDownloadUrl = this.versionHelper.getTerraformBinaryDownloadUrl(
+                this.terraformDownloadBaseUrl, versionNumber, binaryZipFileName);
+        URL url = URI.create(binaryDownloadUrl).toURL();
+        try (ReadableByteChannel rbc = Channels.newChannel(url.openStream());
+                FileOutputStream fos = new FileOutputStream(binaryZipFile, false)) {
+            log.info("Downloading terraform binary file from {} to {}", url,
+                    binaryZipFile.getAbsolutePath());
+            fos.getChannel().transferFrom(rbc, 0, Long.MAX_VALUE);
+            log.info("Downloaded terraform binary file from {} to {} successfully.",
+                    url, binaryZipFile.getAbsolutePath());
+        }
+        return binaryZipFile;
+    }
+
+
+    private void unzipBinaryZipToGetExecutor(File binaryZipFile, String executorName)
+            throws IOException {
+        if (!binaryZipFile.exists()) {
+            String errorMsg = String.format("Terraform binary zip file %s not found.",
+                    binaryZipFile.getAbsolutePath());
+            log.error(errorMsg);
+            throw new IOException(errorMsg);
+        }
+        try (ZipInputStream zis = new ZipInputStream(new FileInputStream(binaryZipFile))) {
+            log.info("Unzipping Terraform zip package {}", binaryZipFile.getAbsolutePath());
+            ZipEntry entry;
+            while ((entry = zis.getNextEntry()) != null) {
+                if (!entry.isDirectory()) {
+                    String entryName = entry.getName();
+                    File entryDestinationFile = new File(this.terraformInstallDir, entryName);
+                    if (isExecutorFileInZipForTerraform(executorName)) {
+                        extractFile(zis, entryDestinationFile);
+                        File executorFile = new File(this.terraformInstallDir, executorName);
+                        Files.move(entryDestinationFile.toPath(), executorFile.toPath(),
+                                StandardCopyOption.REPLACE_EXISTING);
+                        log.info("Unzipped Terraform binary file {} to get the executor {} "
+                                        + "successfully.",
+                                binaryZipFile.getAbsolutePath(), executorFile.getAbsolutePath());
+                    }
+                }
+            }
+        }
+    }
+
+    private boolean isExecutorFileInZipForTerraform(String entryName) {
+        return entryName.startsWith("terraform");
+    }
+
+
+    private void extractFile(ZipInputStream zis, File destinationFile) throws IOException {
+        try (BufferedOutputStream bos = new BufferedOutputStream(
+                new FileOutputStream(destinationFile))) {
+            byte[] bytesIn = new byte[4096];
+            int read;
+            while ((read = zis.read(bytesIn)) != -1) {
+                bos.write(bytesIn, 0, read);
+            }
+        }
+    }
+
+    private void deleteNonExecutorFiles(File dir) {
+        File[] files = dir.listFiles();
+        if (files != null) {
+            for (File file : files) {
+                if (file.isDirectory()) {
+                    deleteNonExecutorFiles(file);
+                } else {
+                    if (!file.getName().startsWith("terraform-") && !file.delete()) {
+                        log.warn("Failed to delete file {}.", file.getAbsolutePath());
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/org/eclipse/xpanse/terraform/boot/terraform/TerraformVersionHelper.java
+++ b/src/main/java/org/eclipse/xpanse/terraform/boot/terraform/TerraformVersionHelper.java
@@ -1,0 +1,323 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ */
+
+package org.eclipse.xpanse.terraform.boot.terraform;
+
+import jakarta.annotation.Resource;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.xpanse.terraform.boot.models.exceptions.InvalidTerraformToolException;
+import org.eclipse.xpanse.terraform.boot.terraform.utils.SystemCmd;
+import org.eclipse.xpanse.terraform.boot.terraform.utils.SystemCmdResult;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.semver4j.Semver;
+import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
+
+/**
+ * Defines methods for handling terraform with required version.
+ */
+@Slf4j
+@Component
+public class TerraformVersionHelper {
+
+    /**
+     * Terraform version required version regex.
+     */
+    public static final String TERRAFORM_REQUIRED_VERSION_REGEX =
+            "^(=|>=|<=)\\s*[vV]?\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}$";
+    private static final Pattern TERRAFORM_REQUIRED_VERSION_PATTERN =
+            Pattern.compile(TERRAFORM_REQUIRED_VERSION_REGEX);
+    private static final Pattern TERRAFORM_VERSION_OUTPUT_PATTERN =
+            Pattern.compile("^Terraform\\s+v(\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})\\b");
+    private static final Pattern TERRAFORM_BINARY_HREF_PATTERN =
+            Pattern.compile("^/terraform/(\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})/");
+    private static final String OS_NAME = System.getProperty("os.name").toLowerCase();
+    private static final String OS_ARCH = System.getProperty("os.arch").toLowerCase();
+
+    @Resource
+    private SystemCmd systemCmd;
+
+    /**
+     * Get terraform executor path which matches the required version.
+     *
+     * @param installationDir  terraform installation directory
+     * @param requiredOperator operator in required version
+     * @param requiredNumber   number in required version
+     * @return return the version of terraform which is matched required, otherwise return null.
+     */
+    public String getExecutorPathMatchedRequiredVersion(String installationDir,
+                                                        String requiredOperator,
+                                                        String requiredNumber) {
+        // Get path of terraform executor matched required version in the installation dir.
+        File installDir = new File(installationDir);
+        if (!installDir.exists() || !installDir.isDirectory()) {
+            return null;
+        }
+        Map<String, File> executorVersionFileMap = new HashMap<>();
+        Arrays.stream(installDir.listFiles())
+                .filter(f -> f.isFile() && f.canExecute() && f.getName().startsWith("terraform-"))
+                .forEach(f -> {
+                    String versionNumber = getVersionFromExecutorPath(f.getAbsolutePath());
+                    executorVersionFileMap.put(versionNumber, f);
+                });
+        if (CollectionUtils.isEmpty(executorVersionFileMap)) {
+            return null;
+        }
+        String findBestVersion = findBestVersion(executorVersionFileMap.keySet().stream().toList(),
+                requiredOperator, requiredNumber);
+        if (StringUtils.isNotBlank(findBestVersion)) {
+            File executorFile = executorVersionFileMap.get(findBestVersion);
+            if (checkIfExecutorVersionIsValid(executorFile, requiredOperator, requiredNumber)) {
+                return executorFile.getAbsolutePath();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Get the operator and number from the required version.
+     *
+     * @param requiredVersion required version
+     * @return string array, the first element is operator, the second element is number.
+     */
+    public String[] getOperatorAndNumberFromRequiredVersion(String requiredVersion) {
+
+        String version = requiredVersion.replaceAll("\\s+", "").toLowerCase()
+                .replaceAll("v", "");
+        if (StringUtils.isNotBlank(version)) {
+            Matcher matcher = TERRAFORM_REQUIRED_VERSION_PATTERN.matcher(version);
+            if (matcher.find()) {
+                String[] operatorAndNumber = new String[2];
+                operatorAndNumber[0] = matcher.group(1);
+                operatorAndNumber[1] = matcher.group(0).replaceAll("^(=|>=|<=)", "");
+                return operatorAndNumber;
+            }
+        }
+        String errorMsg = String.format(
+                "Invalid terraform required version format:%s", requiredVersion);
+        throw new InvalidTerraformToolException(errorMsg);
+    }
+
+
+    /**
+     * Get the best available version in download url.
+     *
+     * @param downloadBaseUrl  the base url of download
+     * @param requiredOperator operator in required version
+     * @param requiredNumber   number in required version
+     * @return the best available version existed in download url.
+     */
+    public String getBestAvailableVersionFromTerraformWebsite(String downloadBaseUrl,
+                                                              String requiredOperator,
+                                                              String requiredNumber) {
+        List<String> allVersionsCanBeDownloaded = new ArrayList<>();
+        try {
+            Document doc = Jsoup.connect(downloadBaseUrl).get();
+            Elements elements = doc.select("a[href]");
+            for (Element element : elements) {
+                String href = element.attr("href");
+                Matcher matcher = TERRAFORM_BINARY_HREF_PATTERN.matcher(href);
+                if (matcher.find()) {
+                    allVersionsCanBeDownloaded.add(matcher.group(1));
+                }
+            }
+        } catch (IOException e) {
+            String errorMsg = String.format("Query all versions of Terraform from the download url"
+                    + " %s error.", downloadBaseUrl);
+            log.error(errorMsg, e);
+        }
+        if (CollectionUtils.isEmpty(allVersionsCanBeDownloaded)) {
+            String errorMsg = String.format("Not found any versions of Terraform from the "
+                    + "download url %s.", downloadBaseUrl);
+            log.error(errorMsg);
+            throw new InvalidTerraformToolException(errorMsg);
+        }
+        return findBestVersion(allVersionsCanBeDownloaded, requiredOperator, requiredNumber);
+    }
+
+    private String findBestVersion(List<String> allAvailableVersions,
+                                   String requiredOperator, String requiredNumber) {
+        if (CollectionUtils.isEmpty(allAvailableVersions)
+                || StringUtils.isBlank(requiredOperator) || StringUtils.isBlank(requiredNumber)) {
+            return null;
+        }
+        Semver requiredSemver = new Semver(requiredNumber);
+        return switch (requiredOperator) {
+            case "=" -> allAvailableVersions.stream()
+                    .filter(v -> new Semver(v).isEqualTo(requiredSemver))
+                    .findAny().orElse(null);
+            case ">=" -> allAvailableVersions.stream()
+                    .filter(v -> new Semver(v).isGreaterThanOrEqualTo(requiredSemver))
+                    .min(Comparator.naturalOrder()).orElse(null);
+            case "<=" -> allAvailableVersions.stream()
+                    .filter(v -> new Semver(v).isLowerThanOrEqualTo(requiredSemver))
+                    .max(Comparator.naturalOrder()).orElse(null);
+            default -> null;
+        };
+    }
+
+    /**
+     * Check if the exact version of terraform executor is valid.
+     *
+     * @param executorFile     executor file
+     * @param requiredOperator operator in required version
+     * @param requiredNumber   number in required version
+     * @return true if the version is valid, otherwise return false.
+     */
+    public boolean checkIfExecutorVersionIsValid(File executorFile, String requiredOperator,
+                                                 String requiredNumber) {
+        if (!executorFile.exists() && !executorFile.isFile()) {
+            return false;
+        }
+        if (!executorFile.canExecute()) {
+            SystemCmdResult chmodResult = systemCmd.execute(
+                    String.format("chmod +x %s", executorFile.getAbsolutePath()),
+                    5, System.getProperty("java.io.tmpdir"), false, new HashMap<>());
+            if (!chmodResult.isCommandSuccessful()) {
+                log.error(chmodResult.getCommandStdError());
+                return false;
+            }
+        }
+        SystemCmdResult versionCheckResult = systemCmd.execute(
+                executorFile.getAbsolutePath() + " -v",
+                5, System.getProperty("java.io.tmpdir"), false, new HashMap<>());
+        if (versionCheckResult.isCommandSuccessful()) {
+            String actualVersion =
+                    getActualVersionFromCommandOutput(versionCheckResult.getCommandStdOutput());
+            return isVersionSatisfied(actualVersion, requiredOperator, requiredNumber);
+        }
+        return false;
+    }
+
+
+    /**
+     * Get the exact version of terraform executor.
+     *
+     * @param executorPath the path of terraform executor
+     * @return the exact version of terraform executor
+     */
+    public String getExactVersionOfExecutor(String executorPath) {
+        if (StringUtils.isBlank(executorPath)) {
+            return null;
+        }
+        String exactVersion;
+        try {
+            SystemCmdResult versionCheckResult = systemCmd.execute(executorPath + " -v",
+                    5, System.getProperty("java.io.tmpdir"), false, new HashMap<>());
+            if (versionCheckResult.isCommandSuccessful()) {
+                exactVersion =
+                        getActualVersionFromCommandOutput(versionCheckResult.getCommandStdOutput());
+            } else {
+                log.error(versionCheckResult.getCommandStdError());
+                exactVersion = getVersionFromExecutorPath(executorPath);
+            }
+        } catch (Exception e) {
+            log.error("Get exact version of the executor {} failed.", executorPath, e);
+            exactVersion = executorPath;
+        }
+        return exactVersion;
+    }
+
+
+    private String getVersionFromExecutorPath(String executorPath) {
+        if (executorPath.contains("-")) {
+            return Arrays.asList(executorPath.split("-")).getLast();
+        }
+        return null;
+    }
+
+    private String getActualVersionFromCommandOutput(String commandOutput) {
+        Matcher matcher = TERRAFORM_VERSION_OUTPUT_PATTERN.matcher(commandOutput);
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+        String errorMsg = String.format("Cannot find the version from command output：%s",
+                commandOutput);
+        throw new InvalidTerraformToolException(errorMsg);
+    }
+
+    private boolean isVersionSatisfied(String actualNumber, String requiredOperator,
+                                       String requiredNumber) {
+        Semver actualSemver = new Semver(actualNumber);
+        Semver requiredSemver = new Semver(requiredNumber);
+        if ("=".equals(requiredOperator)) {
+            return actualSemver.isEqualTo(requiredSemver);
+        } else if (">=".equals(requiredOperator)) {
+            return actualSemver.isGreaterThanOrEqualTo(requiredSemver);
+        } else if ("<=".equals(requiredOperator)) {
+            return actualSemver.isLowerThanOrEqualTo(requiredSemver);
+        }
+        return false;
+    }
+
+
+    /**
+     * Get terraform executor name with version.
+     *
+     * @param versionNumber version number
+     * @return binary file name
+     */
+    public String getTerraformExecutorName(String versionNumber) {
+        return String.format("terraform-%s", versionNumber);
+    }
+
+    /**
+     * Get terraform binary file name.
+     *
+     * @param versionNumber version number
+     * @return binary file name
+     */
+    public String getTerraformBinaryFileName(String versionNumber) {
+        return String.format("terraform_%s_%s_%s.zip",
+                versionNumber, getOperatingSystemCode(), OS_ARCH);
+    }
+
+
+    /**
+     * Get terraform binary file download url.
+     *
+     * @param downloadBaseUrl download base url
+     * @param versionNumber   version number
+     * @param binaryFileName  binary file name
+     * @return binary file name
+     */
+    public String getTerraformBinaryDownloadUrl(String downloadBaseUrl,
+                                                String versionNumber, String binaryFileName) {
+        return String.format("%s/%s/%s", downloadBaseUrl, versionNumber, binaryFileName);
+
+    }
+
+
+    private String getOperatingSystemCode() {
+        if (OS_NAME.contains("windows")) {
+            return "windows";
+        } else if (OS_NAME.contains("linux")) {
+            return "linux";
+        } else if (OS_NAME.contains("mac")) {
+            return "darwin";
+        } else if (OS_NAME.contains("freebsd")) {
+            return "freebsd";
+        } else if (OS_NAME.contains("openbsd")) {
+            return "openbsd";
+        } else if (OS_NAME.contains("solaris") || OS_NAME.contains("sunos")) {
+            return "solaris";
+        }
+        return "Unsupported OS";
+    }
+}

--- a/src/main/java/org/eclipse/xpanse/terraform/boot/terraform/service/TerraformGitRepoService.java
+++ b/src/main/java/org/eclipse/xpanse/terraform/boot/terraform/service/TerraformGitRepoService.java
@@ -41,7 +41,6 @@ import org.springframework.web.client.RestTemplate;
 @Component
 public class TerraformGitRepoService extends TerraformDirectoryService {
 
-    private static final int MAX_RETRY_COUNT = 5;
     private final RestTemplate restTemplate;
     private final TerraformExecutor executor;
     private final TerraformScriptsHelper terraformScriptsHelper;
@@ -68,7 +67,8 @@ public class TerraformGitRepoService extends TerraformDirectoryService {
         UUID uuid = UUID.randomUUID();
         buildDeployEnv(request.getGitRepoDetails(), uuid);
         return tfValidateFromDirectory(
-                getScriptsLocationInRepo(request.getGitRepoDetails(), uuid));
+                getScriptsLocationInRepo(request.getGitRepoDetails(), uuid),
+                request.getTerraformVersion());
     }
 
     /**

--- a/src/main/java/org/eclipse/xpanse/terraform/boot/terraform/service/TerraformScriptsService.java
+++ b/src/main/java/org/eclipse/xpanse/terraform/boot/terraform/service/TerraformScriptsService.java
@@ -63,7 +63,7 @@ public class TerraformScriptsService extends TerraformDirectoryService {
             TerraformDeployWithScriptsRequest request) {
         UUID uuid = UUID.randomUUID();
         buildDeployEnv(request.getScripts(), uuid);
-        return tfValidateFromDirectory(uuid.toString());
+        return tfValidateFromDirectory(uuid.toString(), request.getTerraformVersion());
     }
 
     /**

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,3 +14,7 @@ terraform.log.level=INFO
 otel.exporter.otlp.enabled=false
 terraform.root.module.directory=
 clean.workspace.after.deployment.enabled=true
+spring.retry.max-attempts=3
+spring.retry.delay-millions=1000
+terraform.install.dir=/opt/terraform
+terraform.download.base.url=https://releases.hashicorp.com/terraform

--- a/src/test/java/org/eclipse/xpanse/terraform/boot/terraform/TerraformInstallerTest.java
+++ b/src/test/java/org/eclipse/xpanse/terraform/boot/terraform/TerraformInstallerTest.java
@@ -1,0 +1,55 @@
+package org.eclipse.xpanse.terraform.boot.terraform;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.annotation.Resource;
+import java.io.File;
+import org.eclipse.xpanse.terraform.boot.models.exceptions.InvalidTerraformToolException;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class TerraformInstallerTest {
+
+    @Resource
+    private TerraformInstaller installer;
+    @Resource
+    private TerraformVersionHelper versionHelper;
+
+    @Test
+    void testGetExecutableTerraformByVersion() {
+
+        String requiredVersion = "";
+        String terraformPath = installer.getExecutorPathThatMatchesRequiredVersion(requiredVersion);
+        assertEquals("terraform", terraformPath);
+
+        String requiredVersion1 = "= 1.6.0";
+        String[] operatorAndNumber1 = versionHelper.getOperatorAndNumberFromRequiredVersion(
+                requiredVersion1);
+        String terraformPath1 = installer.getExecutorPathThatMatchesRequiredVersion(requiredVersion1);
+        assertTrue(versionHelper.checkIfExecutorVersionIsValid(new File(terraformPath1),
+                operatorAndNumber1[0], operatorAndNumber1[1]));
+
+        String requiredVersion2 = "<= v1.5.9";
+        String[] operatorAndNumber2 = versionHelper.getOperatorAndNumberFromRequiredVersion(
+                requiredVersion2);
+        String terraformPath2 = installer.getExecutorPathThatMatchesRequiredVersion(requiredVersion2);
+        assertTrue(versionHelper.checkIfExecutorVersionIsValid(new File(terraformPath2),
+                operatorAndNumber2[0], operatorAndNumber2[1]));
+
+        String requiredVersion3 = ">= v1.9.5";
+        String[] operatorAndNumber3 = versionHelper.getOperatorAndNumberFromRequiredVersion(
+                requiredVersion3);
+        String terraformPath3 = installer.getExecutorPathThatMatchesRequiredVersion(requiredVersion3);
+        assertTrue(versionHelper.checkIfExecutorVersionIsValid(new File(terraformPath3),
+                operatorAndNumber3[0], operatorAndNumber3[1]));
+
+        String requiredVersion4 = ">= 100.0.0";
+        assertThrows(InvalidTerraformToolException.class, () ->
+                installer.getExecutorPathThatMatchesRequiredVersion(requiredVersion4));
+
+
+    }
+}


### PR DESCRIPTION
Fixed https://github.com/eclipse-xpanse/xpanse/issues/1939
Install different Terraform executors matched the required versions:

![idea64_BZm8PC8Jc9](https://github.com/user-attachments/assets/1a3aabb1-6dcf-4a4d-9c68-830561455e1f)

