### PR TITLE
Deployment scripts with multiple files

### DIFF
--- a/src/main/java/org/eclipse/xpanse/terraform/boot/models/plan/TerraformPlanWithScriptsRequest.java
+++ b/src/main/java/org/eclipse/xpanse/terraform/boot/models/plan/TerraformPlanWithScriptsRequest.java
@@ -6,8 +6,9 @@
 package org.eclipse.xpanse.terraform.boot.models.plan;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
-import java.util.List;
+import java.util.Map;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -17,8 +18,10 @@ import lombok.EqualsAndHashCode;
 public class TerraformPlanWithScriptsRequest extends TerraformPlanFromDirectoryRequest {
 
     @NotNull
+    @NotEmpty
     @Schema(
             description =
-                    "List of terraform script files to be considered for generating terraform plan")
-    private List<String> scripts;
+                    "Map stores file name and content of all script files for generating terraform"
+                            + " plan.")
+    private Map<String, String> scriptFiles;
 }

--- a/src/main/java/org/eclipse/xpanse/terraform/boot/models/request/scripts/TerraformDeployWithScriptsRequest.java
+++ b/src/main/java/org/eclipse/xpanse/terraform/boot/models/request/scripts/TerraformDeployWithScriptsRequest.java
@@ -6,8 +6,9 @@
 package org.eclipse.xpanse.terraform.boot.models.request.scripts;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
-import java.util.List;
+import java.util.Map;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.eclipse.xpanse.terraform.boot.models.request.directory.TerraformDeployFromDirectoryRequest;
@@ -18,6 +19,9 @@ import org.eclipse.xpanse.terraform.boot.models.request.directory.TerraformDeplo
 public class TerraformDeployWithScriptsRequest extends TerraformDeployFromDirectoryRequest {
 
     @NotNull
-    @Schema(description = "List of Terraform script files to be considered for deploying changes.")
-    private List<String> scripts;
+    @NotEmpty
+    @Schema(
+            description =
+                    "Map stores file name and content of all script files for deploy request.")
+    private Map<String, String> scriptFiles;
 }

--- a/src/main/java/org/eclipse/xpanse/terraform/boot/models/request/scripts/TerraformDestroyWithScriptsRequest.java
+++ b/src/main/java/org/eclipse/xpanse/terraform/boot/models/request/scripts/TerraformDestroyWithScriptsRequest.java
@@ -6,8 +6,9 @@
 package org.eclipse.xpanse.terraform.boot.models.request.scripts;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
-import java.util.List;
+import java.util.Map;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.eclipse.xpanse.terraform.boot.models.request.directory.TerraformDestroyFromDirectoryRequest;
@@ -18,8 +19,11 @@ import org.eclipse.xpanse.terraform.boot.models.request.directory.TerraformDestr
 public class TerraformDestroyWithScriptsRequest extends TerraformDestroyFromDirectoryRequest {
 
     @NotNull
-    @Schema(description = "List of script files for destroy requests deployed via scripts")
-    private List<String> scripts;
+    @NotEmpty
+    @Schema(
+            description =
+                    "Map stores file name and content of all script files for destroy request.")
+    private Map<String, String> scriptFiles;
 
     @NotNull
     @Schema(description = "The .tfState file content after deployment")

--- a/src/main/java/org/eclipse/xpanse/terraform/boot/models/request/scripts/TerraformModifyWithScriptsRequest.java
+++ b/src/main/java/org/eclipse/xpanse/terraform/boot/models/request/scripts/TerraformModifyWithScriptsRequest.java
@@ -6,8 +6,9 @@
 package org.eclipse.xpanse.terraform.boot.models.request.scripts;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
-import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -22,8 +23,11 @@ public class TerraformModifyWithScriptsRequest extends TerraformModifyFromDirect
     private UUID taskId;
 
     @NotNull
-    @Schema(description = "List of script files for modify requests deployed via scripts")
-    private List<String> scripts;
+    @NotEmpty
+    @Schema(
+            description =
+                    "Map stores file name and content of all script files for modify request.")
+    private Map<String, String> scriptFiles;
 
     @NotNull
     @Schema(description = "The .tfState file content after deployment")

--- a/src/main/java/org/eclipse/xpanse/terraform/boot/security/oauth2/config/Oauth2JwtDecoder.java
+++ b/src/main/java/org/eclipse/xpanse/terraform/boot/security/oauth2/config/Oauth2JwtDecoder.java
@@ -35,8 +35,8 @@ public class Oauth2JwtDecoder {
      */
     @Retryable(
             retryFor = Exception.class,
-            maxAttemptsExpression = "${http.request.retry.max.attempts}",
-            backoff = @Backoff(delayExpression = "${http.request.retry.delay.milliseconds}"))
+            maxAttemptsExpression = "${spring.retry.max-attempts}",
+            backoff = @Backoff(delayExpression = "${spring.retry.delay-millions}"))
     public JwtDecoder createJwtDecoder(String issuerUri) {
         int retryCount =
                 Objects.isNull(RetrySynchronizationManager.getContext())

--- a/src/main/java/org/eclipse/xpanse/terraform/boot/terraform/service/TerraformDirectoryService.java
+++ b/src/main/java/org/eclipse/xpanse/terraform/boot/terraform/service/TerraformDirectoryService.java
@@ -11,6 +11,7 @@ import jakarta.annotation.Resource;
 import java.io.File;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.xpanse.terraform.boot.async.TaskConfiguration;
@@ -42,12 +43,13 @@ import org.springframework.web.client.RestTemplate;
 @Slf4j
 @Service
 public class TerraformDirectoryService {
+    private static final String HELLO_WORLD_TF_NAME = "hello_world.tf";
     private static final String HELLO_WORLD_TEMPLATE =
             """
-            output "hello_world" {
-                value = "Hello, World!"
-            }
-            """;
+                    output "hello_world" {
+                        value = "Hello, World!"
+                    }
+                    """;
     @Resource private TerraformExecutor executor;
     @Resource private TerraformInstaller installer;
     @Resource private RestTemplate restTemplate;
@@ -63,7 +65,7 @@ public class TerraformDirectoryService {
     public TerraformBootSystemStatus tfHealthCheck() {
         String taskWorkspace = scriptsHelper.buildTaskWorkspace(UUID.randomUUID().toString());
         scriptsHelper.prepareDeploymentFilesWithScripts(
-                taskWorkspace, List.of(HELLO_WORLD_TEMPLATE), null);
+                taskWorkspace, Map.of(HELLO_WORLD_TF_NAME, HELLO_WORLD_TEMPLATE), null);
         TerraformValidationResult terraformValidationResult =
                 tfValidateFromDirectory(taskWorkspace, null);
         TerraformBootSystemStatus systemStatus = new TerraformBootSystemStatus();
@@ -315,7 +317,8 @@ public class TerraformDirectoryService {
 
     private TerraformResult transSystemCmdResultToTerraformResult(
             SystemCmdResult result, String taskWorkspace, List<File> scriptFiles) {
-        TerraformResult terraformResult = TerraformResult.builder().build();
+        TerraformResult terraformResult =
+                TerraformResult.builder().isCommandSuccessful(result.isCommandSuccessful()).build();
         BeanUtils.copyProperties(result, terraformResult);
         terraformResult.setTerraformState(scriptsHelper.getTerraformState(taskWorkspace));
         terraformResult.setGeneratedFileContentMap(

--- a/src/main/java/org/eclipse/xpanse/terraform/boot/terraform/service/TerraformScriptsService.java
+++ b/src/main/java/org/eclipse/xpanse/terraform/boot/terraform/service/TerraformScriptsService.java
@@ -41,7 +41,8 @@ public class TerraformScriptsService {
     public TerraformValidationResult validateWithScripts(
             TerraformDeployWithScriptsRequest request) {
         String taskWorkspace = scriptsHelper.buildTaskWorkspace(UUID.randomUUID().toString());
-        scriptsHelper.prepareDeploymentFilesWithScripts(taskWorkspace, request.getScripts(), null);
+        scriptsHelper.prepareDeploymentFilesWithScripts(
+                taskWorkspace, request.getScriptFiles(), null);
         return directoryService.tfValidateFromDirectory(
                 taskWorkspace, request.getTerraformVersion());
     }
@@ -51,7 +52,7 @@ public class TerraformScriptsService {
         String taskWorkspace = scriptsHelper.buildTaskWorkspace(uuid.toString());
         List<File> files =
                 scriptsHelper.prepareDeploymentFilesWithScripts(
-                        taskWorkspace, request.getScripts(), null);
+                        taskWorkspace, request.getScriptFiles(), null);
         return directoryService.deployFromDirectory(request, taskWorkspace, files);
     }
 
@@ -60,7 +61,7 @@ public class TerraformScriptsService {
         String taskWorkspace = scriptsHelper.buildTaskWorkspace(uuid.toString());
         List<File> files =
                 scriptsHelper.prepareDeploymentFilesWithScripts(
-                        taskWorkspace, request.getScripts(), request.getTfState());
+                        taskWorkspace, request.getScriptFiles(), request.getTfState());
         return directoryService.modifyFromDirectory(request, taskWorkspace, files);
     }
 
@@ -70,7 +71,7 @@ public class TerraformScriptsService {
         String taskWorkspace = scriptsHelper.buildTaskWorkspace(uuid.toString());
         List<File> files =
                 scriptsHelper.prepareDeploymentFilesWithScripts(
-                        taskWorkspace, request.getScripts(), request.getTfState());
+                        taskWorkspace, request.getScriptFiles(), request.getTfState());
         return directoryService.destroyFromDirectory(request, taskWorkspace, files);
     }
 
@@ -78,7 +79,8 @@ public class TerraformScriptsService {
     public TerraformPlan getTerraformPlanFromScripts(
             TerraformPlanWithScriptsRequest request, UUID uuid) {
         String taskWorkspace = scriptsHelper.buildTaskWorkspace(uuid.toString());
-        scriptsHelper.prepareDeploymentFilesWithScripts(taskWorkspace, request.getScripts(), null);
+        scriptsHelper.prepareDeploymentFilesWithScripts(
+                taskWorkspace, request.getScriptFiles(), null);
         return directoryService.getTerraformPlanFromDirectory(request, uuid.toString());
     }
 


### PR DESCRIPTION
Fixed https://github.com/eclipse-xpanse/xpanse/issues/2195

Validate deployment scripts of registered service template with `terraform-boot`:
![terraform_boot](https://github.com/user-attachments/assets/875c8a91-29f8-46cc-8eba-07fc4e70ebc6)

